### PR TITLE
Rebrand examples including the JS embed library namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# SWITCHtube usage examples
+# Switch Tube usage examples
 
-Usage examples of the [SWITCHtube web service API](http://tube.switch.ch/help/api) and the [SWITCHtube JavaScript embed library](http://tube.switch.ch/help/embed).
+Usage examples of the [Switch Tube web service API](http://tube.switch.ch/help/api) and the [Switch Tube JavaScript embed library](http://tube.switch.ch/help/embed).
 
 ## Web service API
 
-- [download-channel.py](api/download-channel.py) is a Python script that illustrates basic usage of the web service. It allows you to downloading all video from a given channel using an access token from your SWITCHtube profile.
+- [download-channel.py](api/download-channel.py) is a Python script that illustrates basic usage of the web service. It allows you to downloading all video from a given channel using an access token from your Switch Tube profile.
 - [list-channels.py](api/list-channels.py) list channels you can contribute to.
 - [upload.py](api/upload.py) allows you to upload a video to a channel you can contribute to.
 
 ## JavaScript embed library
 
 - [Add and control player](embed/add_player.html) shows how to use the embed library to add a video player inside an existing container element on your page, and how to control playback. This is the preferred way to use the embed library from your JavaScript code. You can also view a [live demo of this example](http://embed-examples.fngtps.com/add_player.html).
-- [Control existing iframe](embed/control_existing_iframe.html) uses the embed library to control playback for a video embedded using the HTML embed code from a SWITCHtube video page. You can also view a [live demo of this example](http://embed-examples.fngtps.com/control_existing_iframe.html).
+- [Control existing iframe](embed/control_existing_iframe.html) uses the embed library to control playback for a video embedded using the HTML embed code from a Switch Tube video page. You can also view a [live demo of this example](http://embed-examples.fngtps.com/control_existing_iframe.html).

--- a/api/download-channel.py
+++ b/api/download-channel.py
@@ -1,11 +1,11 @@
-"""Download all video from a channel using the SWITCHtube web service API.
+"""Download all video from a channel using the Switch Tube web service API.
 
 Assuming the access token `Hbmqqdc8x49Qjk1L3BKBAec`, download all video from
 the channel with id `c61x4b` to a directory named `videos` by running:
 
     $ python3 download-channel.py Hbmqqdc8x49Qjk1L3BKBAec c61x4b ./videos
 
-This script is intended to illustrate usage of the SWITCHtube web service API
+This script is intended to illustrate usage of the Switch Tube web service API
 and is provided “as is”. Please see https://tube.switch.ch/api.html for more
 information.
 
@@ -81,8 +81,8 @@ def download(url, path):
 
 # Define and parse command line arguments.
 parser = argparse.ArgumentParser(
-    description='Download all video from a SWITCHtube channel.')
-parser.add_argument('token', help='access token from your SWITCHtube profile')
+    description='Download all video from a Switch Tube channel.')
+parser.add_argument('token', help='access token from your Switch Tube profile')
 parser.add_argument('channel', help='id of the channel')
 parser.add_argument(
     'target_directory', type=pathlib.Path, help='directory to download to')

--- a/api/list-channels.py
+++ b/api/list-channels.py
@@ -1,11 +1,11 @@
-"""Use the SWITCHtube web service API to list channels you can contribute to.
+"""Use the Switch Tube web service API to list channels you can contribute to.
 
 Assuming the access token `Hbmqqdc8x49Qjk1L3BKBAec`, list the channels you
 can contribute to:
 
     $ python3 list-channels.py Hbmqqdc8x49Qjk1L3BKBAec
 
-This script is intended to illustrate usage of the SWITCHtube web service API
+This script is intended to illustrate usage of the Switch Tube web service API
 and is provided “as is”. Please see https://tube.switch.ch/api.html for more
 information.
 
@@ -23,8 +23,8 @@ ORIGIN = 'https://tube.switch.ch'
 
 # Define and parse command line arguments.
 parser = argparse.ArgumentParser(
-    description='List the channels you own on SWITCHtube.')
-parser.add_argument('token', help='access token from your SWITCHtube profile')
+    description='List the channels you own on Switch Tube.')
+parser.add_argument('token', help='access token from your Switch Tube profile')
 arguments = parser.parse_args()
 
 # Get channels and show their id and title.

--- a/api/upload.py
+++ b/api/upload.py
@@ -1,11 +1,11 @@
-"""Upload a video to a channel using the SWITCHtube web service API.
+"""Upload a video to a channel using the Switch Tube web service API.
 
 Assuming the access token `Hbmqqdc8x49Qjk1L3BKBAec`, upload `video.mp4` to the
 channel with id `42` using `Maths 101` as its title:
 
     $ python3 upload.py Hbmqqdc8x49Qjk1L3BKBAec 42 video.mp4 "Maths 101"
 
-This script is intended to illustrate usage of the SWITCHtube web service API
+This script is intended to illustrate usage of the Switch Tube web service API
 and is provided “as is”. Please see https://tube.switch.ch/api.html for more
 information.
 
@@ -30,8 +30,8 @@ CHUNK_SIZE = 52428800 # 50 megabytes
 
 # Define and parse command line arguments.
 parser = argparse.ArgumentParser(
-    description='Upload a video to a SWITCHtube channel.')
-parser.add_argument('token', help='access token from your SWITCHtube profile')
+    description='Upload a video to a Switch Tube channel.')
+parser.add_argument('token', help='access token from your Switch Tube profile')
 parser.add_argument('channel', help='id of the channel')
 parser.add_argument('path', type=pathlib.Path, help='file to upload')
 parser.add_argument('title', help='video title')

--- a/embed/add_player.html
+++ b/embed/add_player.html
@@ -28,17 +28,17 @@ div#video > iframe
   /* `width: 100%;` and `height: 100%` are set inline by the embed library. */
 }
 </style>
-<!-- Load the SWITCHtube embed library asynchronous. -->
+<!-- Load the Switch Tube embed library asynchronous. -->
 <script async src="https://tube.switch.ch/js/embed.js"></script>
 </head>
 <body>
 
 <hgroup>
-  <h1>SWITCHtube JS embed library</h1>
+  <h1>Switch Tube JS embed library</h1>
   <h2>Add and control player</h2>
 </hgroup>
 
-<p>This example shows how to use the SWITCHtube embed library to add a video
+<p>This example shows how to use the Switch Tube embed library to add a video
 player inside an existing container element, and how to control playback. This
 is the preferred way to use the embed library from your JavaScript code.</p>
 
@@ -72,10 +72,10 @@ player can be controlled.</p>
     let container = document.querySelector('div#video')
 
     // Once the player has been loaded inside the iframe, the embed library
-    // will trigger a `SWITCHtubeEmbed:load` event on the container element.
+    // will trigger a `SwitchTubeEmbed:load` event on the container element.
     // It is recommended to set up usage of the player control object in
     // response to this event.
-    container.addEventListener('SWITCHtubeEmbed:load', (event) => {
+    container.addEventListener('SwitchTubeEmbed:load', (event) => {
       // Get the player control object from the event’s `detail` property.
       let player = event.detail
 
@@ -124,14 +124,14 @@ player can be controlled.</p>
       })
     })
 
-    // With a handler for the `SWITCHtubeEmbed:load` added, the player can be
+    // With a handler for the `SwitchTubeEmbed:load` added, the player can be
     // added and the video loaded. The `player` method requires a reference to
-    // the container element and a SWITCHtube video URL as its arguments.
+    // the container element and a SwitchTube video URL as its arguments.
     //
     // The `player` method returns the same player control object as is
-    // available from the `SWITCHtubeEmbed:load` event’s `detail` property, but
+    // available from the `SwitchTubeEmbed:load` event’s `detail` property, but
     // this is not used here.
-    SWITCHtubeEmbed.player(
+    SwitchTubeEmbed.player(
       // The reference can be an Element instance, a CSS selector, or an
       // element id string. Here we’re using the element assigned above.
       container,
@@ -147,15 +147,15 @@ player can be controlled.</p>
   // Because the embed library is loaded asynchronous, it might or might not be
   // available when your code runs. This is why its usage is wrapped  in the
   // `addVideo` function defined above.
-  if (window.SWITCHtubeEmbed) {
+  if (window.SwitchTubeEmbed) {
     // If the embed library is available, call `addVideo` directly.
     addVideo()
   } else {
     // If the embed library is not yet available, add `addVideo` as the event
-    // handler for the `SWITCHtubeEmbed:ScriptLoaded` event. This event will be
+    // handler for the `SwitchTubeEmbed:ScriptLoaded` event. This event will be
     // triggered by the embed library when it has finished loading to indicate
     // that it is available for usage.
-    window.addEventListener('SWITCHtubeEmbed:ScriptLoaded', addVideo)
+    window.addEventListener('SwitchTubeEmbed:ScriptLoaded', addVideo)
   }
 </script>
 

--- a/embed/control_existing_iframe.html
+++ b/embed/control_existing_iframe.html
@@ -31,14 +31,14 @@ div#video > iframe
 <body>
 
 <hgroup>
-  <h1>SWITCHtube JS embed library</h1>
+  <h1>Switch Tube JS embed library</h1>
   <h2>Control existing iframe</h2>
 </hgroup>
 
 <p>This example shows how to use the embed library to control playback for a
-  video embedded using the HTML embed code from a SWITCHtube video page.</p>
+  video embedded using the HTML embed code from a Switch Tube video page.</p>
 
-<!-- Embed code from a SWITCHtube video page. -->
+<!-- Embed code from a Switch Tube video page. -->
 <iframe width="640" height="360" 
   src="https://tube.switch.ch/embed/d42e0c7f?title=hide"
   frameborder="0" allow="fullscreen" allowfullscreen>
@@ -64,7 +64,7 @@ JavaScript console.</p>
 <script>
   // Get a player control object for the given iframe reference. This reference
   // can be an Element instance, a CSS selector, or an element id string.
-  let player = SWITCHtubeEmbed.control('iframe')
+  let player = SwitchTubeEmbed.control('iframe')
 
   // Add event handlers for the buttons. The methods on the control object will
   // be available before the video player in the iframe has completed loading,


### PR DESCRIPTION
Switch has a new brand identity. As part of this change, SWITCHtube is now known as Switch Tube.

This PR should not be merged until after the rebranding has been deployed to production to make sure that the `SwitchTubeEmbed` namespace is available in the JS embed library (the `SWITCHtubeEmbed` namespace will remain available as an alias).